### PR TITLE
Only one imposter role is assigned

### DIFF
--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -162,7 +162,9 @@ async function eliminatePlayer(gameCode, round, io) {
     const currentRound = await gameModel.getCurrentRound(gameCode);
 
     // Notify players to reload the game page with new round info
-    io.to(gameCode).emit('newRoundStarted', { round: currentRound });
+    io.to(gameCode).emit('newRoundStarted', { 
+      round: currentRound, 
+      eliminatedPlayer: eliminatedPlayer.userId });
   }
 
   return eliminatedPlayer.userId;

--- a/src/public/game.js
+++ b/src/public/game.js
@@ -30,6 +30,7 @@ socket.on('allVotesIn', (data) => {
 socket.on('playerEliminated', (data) => {
   if (data.eliminatedPlayer === playerName) {
     alert('You have been eliminated!');
+    console.log('You have been eliminated!', );
     if(playerRole !== 'undercover') {
       window.location.href = `/eliminated.html?gameCode=${gameCode}&playerName=${playerName}`;
     }
@@ -52,9 +53,11 @@ socket.on('gameEnded', (data) => {
 
 // When new round starts
 socket.on('newRoundStarted', (data) => {
-  alert(`Round ${data.round} started! Your word has been updated.`);
-  // Reload game.html for new round (preserves playerName and gameCode)
-  window.location.href = `/game.html?gameCode=${gameCode}&playerName=${playerName}`;
+  if(data.eliminatedPlayer !== playerName) {
+    alert(`Round ${data.round} started! Your word has been updated.`);
+    // Reload game.html for new round (preserves playerName and gameCode)
+    window.location.href = `/game.html?gameCode=${gameCode}&playerName=${playerName}`;
+  }
 });
 
 // public/game.js


### PR DESCRIPTION
### Summary of Change
Fixed the assign word and roles functionality to ensure only one undercover player is included in the game 9e47019.

### How to Review
* Verify that the game assigns exactly one undercover role per session.

* Confirm word assignments correspond correctly to player roles.

* Test multiple game sessions to ensure consistency and correctness.

### Who Should Review
Anyone in the team can review this.

### Stories
Addresses #66 in particular.
