### PR TITLE
Adding connection string to CI pipeline to align Github actions deployment

### DIFF
--- a/.github/workflows/main_incognito-web-game.yml
+++ b/.github/workflows/main_incognito-web-game.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: '22.x'
 
       - name: npm install, build, and test
+        env:
+          INCOGNITO_CONNECTION_STRING: ${{ secrets.INCOGNITO_CONNECTION_STRING }}
         run: |
           npm install
           npm run build --if-present

--- a/__tests__/gameModels.test.js
+++ b/__tests__/gameModels.test.js
@@ -1,4 +1,4 @@
-/*const gameModel = require('../src/models/gameModels');
+const gameModel = require('../src/models/gameModels');
 const db = require('../src/config/db');
 
 let pool;
@@ -188,7 +188,7 @@ describe('assignRolesAndWords integration tests', () => {
       }
     });
   }, 20000);
-});*/
+});
 
 
 describe('gameModel dummy test', () => {

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -4,7 +4,7 @@ require('dotenv').config();
 const config = {
   connectionString: process.env.INCOGNITO_CONNECTION_STRING,
   options: {
-    encrypt: true,
+    encrypt: true,  // for Azure
   },
 };
 
@@ -15,9 +15,12 @@ const poolPromise = mssql.connect(config.connectionString)
   })
   .catch(err => {
     console.error('❌ Database connection failed:', err);
+    throw err;  // Important: re-throw error to avoid resolving to undefined
   });
 
+
 module.exports = {
+  connectionString: process.env.INCOGNITO_CONNECTION_STRING,
   sql: mssql,
   poolPromise,
 };


### PR DESCRIPTION
Summary of commit: 
In commit 88a7f26 I have added the database connection string to the CI pipeline. This is potentially what keeps making our integration tests with the database fail. I have uncommented the integration tests to run those tests. 

Who should review this PR: 
@okwukwe-bit should review this PR. Please check whether the changes made to db.js do not cause major flaws in codebase. 