### PR TITLE
Remove eliminated players from votelist

### DIFF
--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -164,40 +164,38 @@ async function eliminatePlayer(gameCode, round, io) {
   // Fetch updated players list to send in update
   const updatedPlayers = await gameModel.getPlayersByGameCode(gameCode);
 
-  // Get current active players
-  const activePlayers = updatedPlayers.filter(player => player.status === 'active');
-  const remainingCivilians = activePlayers.filter(player => player.role === 'civilian');
-  const remainingUndercover = activePlayers.filter(player => player.role === 'undercover');
-
-  const totalPlayers = activePlayers.length;
-
-  console.log(`Total players: ${totalPlayers}`);
-  console.log(`Remaining civilians: ${remainingCivilians.length}`);
-  console.log(`Remaining undercover: ${remainingUndercover.length}`);
-
   // Emit elimination event to all clients in the room
   io.to(gameCode).emit('playerEliminated', {
     eliminatedPlayer: eliminatedPlayer.userId,
     players: updatedPlayers
   });
 
-  console.log(`Player ${eliminatedPlayer.userId} eliminated. Role: ${eliminatedPlayerRole.role}`);
   if (eliminatedPlayerRole.role === 'undercover') {
-    // Impostor eliminated → Game ends, civilians win
+    // Undercover eliminated → Game ends, civilians win
     await gameModel.endGame(gameCode, 'civilian');
-    console.log(`Emitting gameEnded event to room ${gameCode} - winner: civilian`);
     io.to(gameCode).emit('gameEnded', { winner: 'civilian' });
   } else {
-    // Civilian eliminated → Start next round
-    await gameModel.incrementRound(gameCode);
-    await gameModel.assignNewWords(gameCode);
+    // Civilian eliminated → Check if undercover wins or continue game
+    const remainingPlayers = await gameModel.getActivePlayers(gameCode);
+    const remainingCivilians = remainingPlayers.filter(p => p.role === 'civilian').length;
+    const remainingUndercover = remainingPlayers.filter(p => p.role === 'undercover').length;
+
+    // Undercover wins if they equal or outnumber civilians (typically when 2 players left: 1 undercover, 1 civilian)
+    if (remainingUndercover >= remainingCivilians || remainingPlayers.length <= 2) {
+      await gameModel.endGame(gameCode, 'undercover');
+      io.to(gameCode).emit('gameEnded', { winner: 'undercover' });
+    } else {
+      // Continue to next round
+      await gameModel.incrementRound(gameCode);
+      await gameModel.assignNewWords(gameCode);
 
       const currentRound = await gameModel.getCurrentRound(gameCode);
 
-    // Notify players to reload the game page with new round info
-    io.to(gameCode).emit('newRoundStarted', { 
-      round: currentRound, 
-      eliminatedPlayer: eliminatedPlayer.userId });
+      // Notify players to reload the game page with new round info
+      io.to(gameCode).emit('newRoundStarted', {
+        round: currentRound,
+        eliminatedPlayer: eliminatedPlayer.userId });
+    }
   }
 
   return eliminatedPlayer.userId;

--- a/src/public/game.js
+++ b/src/public/game.js
@@ -181,6 +181,7 @@ async function startVote() {
 
     players.forEach(player => {
       if (player.userId === playerName) return;
+      if (player.status === 'eliminated') return;
       const btn = document.createElement('button');
       btn.className = 'btn btn-outline-danger m-1';
       btn.innerText = `Vote ${player.userId}`;


### PR DESCRIPTION
### Summary of Commits
d2f34e2: Updated the voting logic to ensure that eliminated players are no longer displayed in the voting list.

f05f618: Fixed a bug in the game-ending logic where the undercover player was not being recognized as the winner due to faulty conditions.

### Review Request
Anyone is welcome to review this pull request — especially to confirm that:

* Eliminated players are correctly excluded from voting.

* The game now ends accurately when the undercover should win.